### PR TITLE
Fix Gamma API evasion attack

### DIFF
--- a/secml_malware/attack/blackbox/c_gammapi_evasion.py
+++ b/secml_malware/attack/blackbox/c_gammapi_evasion.py
@@ -1,4 +1,7 @@
 import copy
+import os
+import magic
+import random
 
 import lief
 from secml.array import CArray
@@ -75,3 +78,35 @@ class CGammaAPIEvasionProblem(CBlackBoxProblem):
 		x_adv = CArray(builder.get_build())
 		x_adv = x_adv.reshape((1, x_adv.shape[-1]))
 		return x_adv
+
+	@classmethod
+	def extract_api_calls_from_folder(cls, folder: str, how_many: int) -> list:
+		"""
+		Extract api calls from a given folder
+
+		Parameters
+		----------
+		folder : str
+			the folder containing programs used for extracting sections
+		how_many : int
+			how many api calls to extract in general
+
+		Returns
+		-------
+		list
+			a list of (lib name, function name)
+		"""
+
+		api_calls = []
+		for filename in os.listdir(folder):
+			path = os.path.join(folder, filename)
+			if "PE" not in magic.from_file(path):
+				continue
+			lief_pe_file = lief.PE.parse(path)
+			for lib in lief_pe_file.imports:
+				for fun in lib.entries:
+					api_calls.append((lib.name,fun.name))
+		api_calls = list(set(api_calls)) # remove duplicates
+		api_calls = random.sample(api_calls, how_many)
+		return api_calls
+

--- a/secml_malware/attack/blackbox/c_gammapi_evasion.py
+++ b/secml_malware/attack/blackbox/c_gammapi_evasion.py
@@ -57,9 +57,7 @@ class CGammaAPIEvasionProblem(CBlackBoxProblem):
 
 	def _add_import(self, liefpe, dll, func_name):
 		lib = [l for l in liefpe.imports if l.name.lower() == dll.lower()]
-		if lib == []:
-			lib = liefpe.add_library(dll)
-		lib = lief.add_library(dll) if lib == [] else lib[0]
+		lib = liefpe.add_library(dll) if lib == [] else lib[0]
 		names = set([e.name for e in lib.entries])
 		if not func_name in names:
 			lib.add_entry(func_name)


### PR DESCRIPTION
The Gamma API evasion attacks didn’t work. The error was:

```
__eq__(): incompatible function arguments. The following argument types are supported:
    1. (self: lief.PE.Import, arg0: lief.PE.Import) -> bool
Invoked with: <lief.PE.Import object at 0x7f10e4959530>, []
```

This pull request fixes the attack.