### PR TITLE
pin numpy version to <2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ RUN pip install -r /ramen/secml_malware/requirements.txt
 RUN pip install torch torchvision
 RUN pip install -e /ramen/secml_malware
 RUN pip install ipython
+RUN pip install "numpy<2"


### PR DESCRIPTION
Fixed the following error due to numpy version >= 2.0 which occured, for example, when running [blackbox_tutorial.ipynb](https://github.com/pralab/secml_malware/blob/master/blackbox_tutorial.ipynb)

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 12
     10     code = file_handle.read()
     11 x = CArray(np.frombuffer(code, dtype=np.uint8)).atleast_2d()
---> 12 _, confidence = net.predict(x, True)
     14 if confidence[0, 1].item() < 0.5:
     15     continue

File /ramen/secml_malware/secml_malware/attack/blackbox/c_wrapper_phi.py:69, in CWrapperPhi.predict(self, x, return_decision_function)
     60 # feature_vectors = []
     61 # for i in range(x.shape[0]):
     62 # 	x_i = x[i, :]
   (...)
     66 # 	feature_vectors.append(self.extract_features(x_i))
     67 # feature_vectors = CArray(feature_vectors)
     68 feature_vectors = self.extract_features(x)
---> 69 return self.classifier.predict(feature_vectors, return_decision_function=return_decision_function)

File /usr/local/lib/python3.9/site-packages/secml/ml/classifiers/c_classifier.py:293, in CClassifier.predict(self, x, return_decision_function)
    266 def predict(self, x, return_decision_function=False):
    267     """Perform classification of each pattern in x.
    268 
    269     If preprocess has been specified,
   (...)
    291 
    292     """
--> 293     scores = self.decision_function(x, y=None)
    295     # The classification label is the label of the class
    296     # associated with the highest score
    297     labels = scores.argmax(axis=1).ravel()

File /usr/local/lib/python3.9/site-packages/secml/ml/classifiers/c_classifier.py:222, in CClassifier.decision_function(self, x, y)
    194 def decision_function(self, x, y=None):
    195     """Computes the decision function for each pattern in x.
    196 
    197     If a preprocess has been specified, input is normalized
   (...)
    220 
    221     """
--> 222     scores = self.forward(x, caching=False)
    223     return scores if y is None else scores[:, y].ravel()

File /usr/local/lib/python3.9/site-packages/secml/ml/c_module.py:199, in CModule.forward(self, x, caching)
    179 """Forward pass on input x.
    180 This function internally calls self._preprocess_data(x) to handle
    181 caching of intermediate representation of the input data x.
   (...)
    196 
    197 """
    198 x, y = self._check_input(x)
--> 199 self._check_is_fitted()
    200 self._clear_cache()
    202 # Transform data using inner preprocess, if defined

File /usr/local/lib/python3.9/site-packages/secml/ml/classifiers/c_classifier.py:91, in CClassifier._check_is_fitted(self)
     82 def _check_is_fitted(self):
     83     """Check if the classifier is trained (fitted).
     84 
     85     Raises
   (...)
     89 
     90     """
---> 91     check_is_fitted(self, ['classes', 'n_features'])

File /usr/local/lib/python3.9/site-packages/secml/utils/mixed_utils.py:151, in check_is_fitted(obj, attributes, msg, check_all)
    148 if not hasattr(obj, 'fit'):
    149     raise TypeError("`{:}` does not implement `.fit()`.".format(obj))
--> 151 if is_str(attributes):
    152     attributes = [attributes]
    153 elif not is_list(attributes):

File /usr/local/lib/python3.9/site-packages/secml/core/type_utils.py:275, in is_str(x)
    273 if isinstance(x, str):
    274     return True
--> 275 elif isinstance(x, (np.str_, np.unicode_)):
    276     return True
    277 return False

File /usr/local/lib/python3.9/site-packages/numpy/__init__.py:397, in __getattr__(attr)
    394     raise AttributeError(__former_attrs__[attr])
    396 if attr in __expired_attributes__:
--> 397     raise AttributeError(
    398         f"`np.{attr}` was removed in the NumPy 2.0 release. "
    399         f"{__expired_attributes__[attr]}"
    400     )
    402 if attr == "chararray":
    403     warnings.warn(
    404         "`np.chararray` is deprecated and will be removed from "
    405         "the main namespace in the future. Use an array with a string "
    406         "or bytes dtype instead.", DeprecationWarning, stacklevel=2)

AttributeError: `np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
```